### PR TITLE
Create State and Transition traits

### DIFF
--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -38,8 +38,7 @@ use crate::witness::memory::{
 use crate::witness::operation::{Operation, CONTEXT_SCALING_FACTOR};
 use crate::witness::state::RegistersState;
 use crate::witness::transition::{
-    decode, fill_op_flag, get_op_special_length, log_kernel_instruction, perform_state_op,
-    Transition,
+    decode, fill_op_flag, get_op_special_length, log_kernel_instruction, Transition,
 };
 use crate::witness::util::{push_no_write, stack_peek};
 use crate::{arithmetic, logic};
@@ -865,7 +864,7 @@ impl<F: Field> State<F> for Interpreter<F> {
             row.general.stack_mut().stack_inv_aux = F::ONE;
         }
 
-        perform_state_op(self, opcode, op, row)
+        self.perform_state_op(opcode, op, row)
     }
 }
 

--- a/evm_arithmetization/src/cpu/kernel/interpreter.rs
+++ b/evm_arithmetization/src/cpu/kernel/interpreter.rs
@@ -379,7 +379,7 @@ impl<F: Field> Interpreter<F> {
     }
 
     pub(crate) fn run(&mut self) -> Result<(), anyhow::Error> {
-        self.run_cpu(false)?;
+        self.run_cpu()?;
 
         #[cfg(debug_assertions)]
         {

--- a/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
@@ -28,10 +28,11 @@ fn test_init_access_lists() -> Result<()> {
 
     let acc_addr_list: Vec<U256> = (0..2)
         .map(|i| {
-            interpreter.generation_state.memory.get(
-                MemoryAddress::new(0, Segment::AccessedAddresses, i),
-                &HashMap::default(),
-            )
+            interpreter.generation_state.memory.get(MemoryAddress::new(
+                0,
+                Segment::AccessedAddresses,
+                i,
+            ))
         })
         .collect();
     assert_eq!(
@@ -41,10 +42,11 @@ fn test_init_access_lists() -> Result<()> {
 
     let acc_storage_keys: Vec<U256> = (0..4)
         .map(|i| {
-            interpreter.generation_state.memory.get(
-                MemoryAddress::new(0, Segment::AccessedStorageKeys, i),
-                &HashMap::default(),
-            )
+            interpreter.generation_state.memory.get(MemoryAddress::new(
+                0,
+                Segment::AccessedStorageKeys,
+                i,
+            ))
         })
         .collect();
 
@@ -111,10 +113,10 @@ fn test_insert_address() -> Result<()> {
     interpreter.run()?;
     assert_eq!(interpreter.stack(), &[U256::one()]);
     assert_eq!(
-        interpreter.generation_state.memory.get(
-            MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),
-            &HashMap::default(),
-        ),
+        interpreter
+            .generation_state
+            .memory
+            .get(MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),),
         U256::from(Segment::AccessedAddresses as usize + 4)
     );
 
@@ -167,7 +169,7 @@ fn test_insert_accessed_addresses() -> Result<()> {
         assert_eq!(
             interpreter.generation_state.memory.get(
                 MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),
-                &HashMap::default(),
+            
             ),
             U256::from(offset + 2 * (n + 1))
         );
@@ -181,17 +183,18 @@ fn test_insert_accessed_addresses() -> Result<()> {
     interpreter.run()?;
     assert_eq!(interpreter.stack(), &[U256::one()]);
     assert_eq!(
-        interpreter.generation_state.memory.get(
-            MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),
-            &HashMap::default(),
-        ),
+        interpreter
+            .generation_state
+            .memory
+            .get(MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),),
         U256::from(offset + 2 * (n + 2))
     );
     assert_eq!(
-        interpreter.generation_state.memory.get(
-            MemoryAddress::new(0, AccessedAddresses, 2 * (n + 1)),
-            &HashMap::default(),
-        ),
+        interpreter.generation_state.memory.get(MemoryAddress::new(
+            0,
+            AccessedAddresses,
+            2 * (n + 1)
+        ),),
         U256::from(addr_not_in_list.0.as_slice())
     );
 
@@ -252,8 +255,7 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
         assert_eq!(interpreter.pop().unwrap(), value);
         assert_eq!(
             interpreter.generation_state.memory.get(
-                MemoryAddress::new_bundle(U256::from(AccessedStorageKeysLen as usize)).unwrap(),
-                &HashMap::default(),
+                MemoryAddress::new_bundle(U256::from(AccessedStorageKeysLen as usize)).unwrap(),               
             ),
             U256::from(offset + 4 * (n + 1))
         );
@@ -273,29 +275,26 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     );
     assert_eq!(
         interpreter.generation_state.memory.get(
-            MemoryAddress::new_bundle(U256::from(AccessedStorageKeysLen as usize)).unwrap(),
-            &HashMap::default()
+            MemoryAddress::new_bundle(U256::from(AccessedStorageKeysLen as usize)).unwrap(),   
         ),
         U256::from(offset + 4 * (n + 2))
     );
     assert_eq!(
         interpreter.generation_state.memory.get(
-            MemoryAddress::new(0, AccessedStorageKeys, 4 * (n + 1)),
-            &HashMap::default(),
+            MemoryAddress::new(0, AccessedStorageKeys, 4 * (n + 1)),    
         ),
         U256::from(storage_key_not_in_list.0 .0.as_slice())
     );
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new(0, AccessedStorageKeys, 4 * (n + 1) + 1),
-            &HashMap::default()
+           
         ),
         storage_key_not_in_list.1
     );
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new(0, AccessedStorageKeys, 4 * (n + 1) + 2),
-            &HashMap::default()
         ),
         storage_key_not_in_list.2
     );

--- a/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/core/access_lists.rs
@@ -30,7 +30,6 @@ fn test_init_access_lists() -> Result<()> {
         .map(|i| {
             interpreter.generation_state.memory.get(
                 MemoryAddress::new(0, Segment::AccessedAddresses, i),
-                false,
                 &HashMap::default(),
             )
         })
@@ -44,7 +43,6 @@ fn test_init_access_lists() -> Result<()> {
         .map(|i| {
             interpreter.generation_state.memory.get(
                 MemoryAddress::new(0, Segment::AccessedStorageKeys, i),
-                false,
                 &HashMap::default(),
             )
         })
@@ -115,7 +113,6 @@ fn test_insert_address() -> Result<()> {
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),
-            false,
             &HashMap::default(),
         ),
         U256::from(Segment::AccessedAddresses as usize + 4)
@@ -170,7 +167,6 @@ fn test_insert_accessed_addresses() -> Result<()> {
         assert_eq!(
             interpreter.generation_state.memory.get(
                 MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),
-                false,
                 &HashMap::default(),
             ),
             U256::from(offset + 2 * (n + 1))
@@ -187,7 +183,6 @@ fn test_insert_accessed_addresses() -> Result<()> {
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new_bundle(U256::from(AccessedAddressesLen as usize)).unwrap(),
-            false,
             &HashMap::default(),
         ),
         U256::from(offset + 2 * (n + 2))
@@ -195,7 +190,6 @@ fn test_insert_accessed_addresses() -> Result<()> {
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new(0, AccessedAddresses, 2 * (n + 1)),
-            false,
             &HashMap::default(),
         ),
         U256::from(addr_not_in_list.0.as_slice())
@@ -259,7 +253,6 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
         assert_eq!(
             interpreter.generation_state.memory.get(
                 MemoryAddress::new_bundle(U256::from(AccessedStorageKeysLen as usize)).unwrap(),
-                false,
                 &HashMap::default(),
             ),
             U256::from(offset + 4 * (n + 1))
@@ -281,7 +274,6 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new_bundle(U256::from(AccessedStorageKeysLen as usize)).unwrap(),
-            false,
             &HashMap::default()
         ),
         U256::from(offset + 4 * (n + 2))
@@ -289,7 +281,6 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new(0, AccessedStorageKeys, 4 * (n + 1)),
-            false,
             &HashMap::default(),
         ),
         U256::from(storage_key_not_in_list.0 .0.as_slice())
@@ -297,7 +288,6 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new(0, AccessedStorageKeys, 4 * (n + 1) + 1),
-            false,
             &HashMap::default()
         ),
         storage_key_not_in_list.1
@@ -305,7 +295,6 @@ fn test_insert_accessed_storage_keys() -> Result<()> {
     assert_eq!(
         interpreter.generation_state.memory.get(
             MemoryAddress::new(0, AccessedStorageKeys, 4 * (n + 1) + 2),
-            false,
             &HashMap::default()
         ),
         storage_key_not_in_list.2

--- a/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
@@ -210,14 +210,11 @@ mod bn {
 
         let mut computed_table = Vec::new();
         for i in 0..32 {
-            computed_table.push(int.generation_state.memory.get(
-                MemoryAddress {
-                    context: 0,
-                    segment: Segment::BnTableQ.unscale(),
-                    virt: i,
-                },
-                &HashMap::default(),
-            ));
+            computed_table.push(int.generation_state.memory.get(MemoryAddress {
+                context: 0,
+                segment: Segment::BnTableQ.unscale(),
+                virt: i,
+            }));
         }
 
         let table = u256ify([

--- a/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
+++ b/evm_arithmetization/src/cpu/kernel/tests/ecc/curve_ops.rs
@@ -216,7 +216,6 @@ mod bn {
                     segment: Segment::BnTableQ.unscale(),
                     virt: i,
                 },
-                false,
                 &HashMap::default(),
             ));
         }

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -28,7 +28,6 @@ use crate::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, Tri
 use crate::util::{h2u, u256_to_u8, u256_to_usize};
 use crate::witness::memory::{MemoryAddress, MemoryChannel, MemoryOp, MemoryOpKind};
 use crate::witness::state::RegistersState;
-use crate::witness::transition::transition;
 
 pub mod mpt;
 pub(crate) mod prover_input;
@@ -36,7 +35,7 @@ pub(crate) mod rlp;
 pub(crate) mod state;
 mod trie_extractor;
 
-use self::state::GenerationStateCheckpoint;
+use self::state::{GenerationStateCheckpoint, State};
 use crate::witness::util::{mem_write_log, stack_peek};
 
 /// Inputs needed for trace generation.
@@ -312,199 +311,8 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     Ok((tables, public_values))
 }
 
-/// A State is either an `Interpreter` (used for tests and jumpdest analysis) or
-/// a `GenerationState`.
-pub(crate) enum State<'a, F: Field> {
-    Generation(&'a mut GenerationState<F>),
-    Interpreter(&'a mut Interpreter<F>),
-}
-
-impl<'a, F: Field> State<'a, F> {
-    /// Returns a `State`'s `Checkpoint`.
-    pub(crate) fn checkpoint(&mut self) -> GenerationStateCheckpoint {
-        match self {
-            Self::Generation(state) => state.checkpoint(),
-            Self::Interpreter(interpreter) => interpreter.checkpoint(),
-        }
-    }
-
-    /// Increments the `gas_used` register by a value `n`.
-    pub(crate) fn incr_gas(&mut self, n: u64) {
-        match self {
-            Self::Generation(state) => state.registers.gas_used += n,
-            Self::Interpreter(interpreter) => interpreter.generation_state.registers.gas_used += n,
-        }
-    }
-
-    /// Increments the `program_counter` register by a value `n`.
-    pub(crate) fn incr_pc(&mut self, n: usize) {
-        match self {
-            Self::Generation(state) => state.registers.program_counter += n,
-            Self::Interpreter(interpreter) => {
-                interpreter.generation_state.registers.program_counter += n
-            }
-        }
-    }
-
-    /// Returns a `State`'s registers.
-    pub(crate) fn get_registers(&self) -> RegistersState {
-        match self {
-            Self::Generation(state) => state.registers,
-            Self::Interpreter(interpreter) => interpreter.generation_state.registers,
-        }
-    }
-
-    /// Returns a `State`'s mutable registers.
-    pub(crate) fn get_mut_registers(&mut self) -> &mut RegistersState {
-        match self {
-            Self::Generation(state) => &mut state.registers,
-            Self::Interpreter(interpreter) => &mut interpreter.generation_state.registers,
-        }
-    }
-
-    /// Returns the value stored at address `address` in a `State`.
-    pub(crate) fn get_from_memory(&mut self, address: MemoryAddress) -> U256 {
-        match self {
-            Self::Generation(state) => state.memory.get(address, false, &HashMap::default()),
-            Self::Interpreter(interpreter) => interpreter.generation_state.memory.get(
-                address,
-                true,
-                &interpreter.preinitialized_segments,
-            ),
-        }
-    }
-
-    /// Returns a mutable `GenerationState` from a `State`.
-    pub(crate) fn get_mut_generation_state(&mut self) -> &mut GenerationState<F> {
-        match self {
-            Self::Generation(state) => state,
-            Self::Interpreter(interpreter) => &mut interpreter.generation_state,
-        }
-    }
-
-    /// Returns true if a `State` is a `GenerationState` and false otherwise.
-    pub(crate) fn is_generation_state(&mut self) -> bool {
-        match self {
-            Self::Generation(state) => true,
-            Self::Interpreter(interpreter) => false,
-        }
-    }
-
-    /// Increments the clock of an `Interpreter`'s clock.
-    pub(crate) fn incr_interpreter_clock(&mut self) {
-        match self {
-            Self::Generation(state) => {}
-            Self::Interpreter(interpreter) => interpreter.clock += 1,
-        }
-    }
-
-    /// Returns the value of a `State`'s clock.
-    pub(crate) fn get_clock(&mut self) -> usize {
-        match self {
-            Self::Generation(state) => state.traces.clock(),
-            Self::Interpreter(interpreter) => interpreter.clock,
-        }
-    }
-
-    /// Rolls back a `State`.
-    pub(crate) fn rollback(&mut self, checkpoint: GenerationStateCheckpoint) {
-        match self {
-            Self::Generation(state) => state.rollback(checkpoint),
-            Self::Interpreter(interpreter) => interpreter.generation_state.rollback(checkpoint),
-        }
-    }
-
-    /// Returns a `State`'s stack.
-    pub(crate) fn get_stack(&mut self) -> Vec<U256> {
-        match self {
-            Self::Generation(state) => state.stack(),
-            Self::Interpreter(interpreter) => interpreter.stack(),
-        }
-    }
-
-    fn get_context(&mut self) -> usize {
-        match self {
-            Self::Generation(state) => state.registers.context,
-            Self::Interpreter(interpreter) => interpreter.context(),
-        }
-    }
-
-    fn get_halt_context(&mut self) -> Option<usize> {
-        match self {
-            Self::Generation(state) => None,
-            Self::Interpreter(interpreter) => interpreter.halt_context,
-        }
-    }
-
-    /// Returns the content of a the `KernelGeneral` segment of a `State`.
-    pub(crate) fn mem_get_kernel_content(&self) -> Vec<Option<U256>> {
-        match self {
-            Self::Generation(state) => state.memory.contexts[0].segments
-                [Segment::KernelGeneral.unscale()]
-            .content
-            .clone(),
-            Self::Interpreter(interpreter) => interpreter.generation_state.memory.contexts[0]
-                .segments[Segment::KernelGeneral.unscale()]
-            .content
-            .clone(),
-        }
-    }
-
-    /// Applies a `State`'s operations since a checkpoint.
-    pub(crate) fn apply_ops(&mut self, checkpoint: GenerationStateCheckpoint) {
-        match self {
-            Self::Generation(state) => state
-                .memory
-                .apply_ops(state.traces.mem_ops_since(checkpoint.traces)),
-            Self::Interpreter(interpreter) => {
-                // An interpreter `checkpoint()` clears all operations before the checkpoint.
-                interpreter.apply_memops();
-            }
-        }
-    }
-}
-
-/// Simulates a CPU. It only generates the traces if the `State` is a
-/// `GenerationState`. Otherwise, it simply simulates all ooperations.
-pub(crate) fn run_cpu<F: Field>(
-    any_state: &mut State<F>,
-    is_generation: bool,
-) -> anyhow::Result<()> {
-    let halt_offsets = match any_state {
-        State::Generation(state) => vec![KERNEL.global_labels["halt"]],
-        State::Interpreter(interpreter) => interpreter.halt_offsets.clone(),
-    };
-
-    loop {
-        // If we've reached the kernel's halt routine.
-        let registers = any_state.get_registers();
-        let pc = registers.program_counter;
-
-        let halt = registers.is_kernel && halt_offsets.contains(&pc);
-
-        if halt {
-            if let Some(halt_context) = any_state.get_halt_context() {
-                if registers.context == halt_context {
-                    // Only happens during jumpdest analysis.
-                    return Ok(());
-                }
-            } else {
-                if is_generation {
-                    log::info!("CPU halted after {} cycles", any_state.get_clock());
-                }
-                return Ok(());
-            }
-        }
-
-        transition(any_state)?;
-        any_state.incr_interpreter_clock();
-    }
-
-    Ok(())
-}
-
 fn simulate_cpu<F: Field>(state: &mut GenerationState<F>) -> anyhow::Result<()> {
-    run_cpu(&mut State::Generation(state), true)?;
+    state.run_cpu(true)?;
 
     let pc = state.registers.program_counter;
     // Padding

--- a/evm_arithmetization/src/generation/mod.rs
+++ b/evm_arithmetization/src/generation/mod.rs
@@ -312,7 +312,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
 }
 
 fn simulate_cpu<F: Field>(state: &mut GenerationState<F>) -> anyhow::Result<()> {
-    state.run_cpu(true)?;
+    state.run_cpu()?;
 
     let pc = state.registers.program_counter;
     // Padding

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -423,7 +423,6 @@ impl<F: Field> GenerationState<F> {
             .map(|i| {
                 u256_to_u8(self.memory.get(
                     MemoryAddress::new(context, Segment::Code, i),
-                    false,
                     &HashMap::default(),
                 ))
             })
@@ -438,7 +437,6 @@ impl<F: Field> GenerationState<F> {
                 Segment::ContextMetadata,
                 ContextMetadata::CodeSize.unscale(),
             ),
-            false,
             &HashMap::default(),
         ))?;
         Ok(code_len)
@@ -477,7 +475,6 @@ impl<F: Field> GenerationState<F> {
     fn get_global_metadata(&self, data: GlobalMetadata) -> U256 {
         self.memory.get(
             MemoryAddress::new(0, Segment::GlobalMetadata, data.unscale()),
-            false,
             &HashMap::default(),
         )
     }
@@ -493,7 +490,6 @@ impl<F: Field> GenerationState<F> {
                     Segment::GlobalMetadata,
                     GlobalMetadata::AccessedStorageKeysLen.unscale(),
                 ),
-                false,
                 &HashMap::default(),
             ) - Segment::AccessedStorageKeys as usize,
         )?;

--- a/evm_arithmetization/src/generation/prover_input.rs
+++ b/evm_arithmetization/src/generation/prover_input.rs
@@ -9,6 +9,7 @@ use num_bigint::BigUint;
 use plonky2::field::types::Field;
 use serde::{Deserialize, Serialize};
 
+use super::state::State;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cpu::kernel::interpreter::simulate_cpu_and_get_user_jumps;

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -74,7 +74,9 @@ pub(crate) trait State<F: Field> {
     /// Returns the current context.
     fn get_context(&mut self) -> usize;
 
-    fn get_halt_context(&mut self) -> Option<usize>;
+    fn get_halt_context(&mut self) -> Option<usize> {
+        None
+    }
 
     /// Returns the content of a the `KernelGeneral` segment of a `State`.
     fn mem_get_kernel_content(&self) -> Vec<Option<U256>>;
@@ -448,10 +450,6 @@ impl<F: Field> State<F> for GenerationState<F> {
 
     fn get_context(&mut self) -> usize {
         self.registers.context
-    }
-
-    fn get_halt_context(&mut self) -> Option<usize> {
-        None
     }
 
     /// Returns the content of a the `KernelGeneral` segment of a `State`.

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -26,7 +26,7 @@ use crate::witness::state::RegistersState;
 use crate::witness::traces::{TraceCheckpoint, Traces};
 use crate::witness::transition::{
     decode, fill_op_flag, get_op_special_length, log_kernel_instruction, might_overflow_op,
-    perform_state_op, read_code_memory, Transition,
+    read_code_memory, Transition,
 };
 use crate::witness::util::{
     fill_channel_with_value, mem_read_gp_with_log_and_fill, stack_peek, stack_pop_with_log_and_fill,
@@ -505,7 +505,7 @@ impl<F: Field> State<F> for GenerationState<F> {
             row.general.stack_mut().stack_inv_aux = F::ONE;
         }
 
-        perform_state_op(self, opcode, op, row)
+        self.perform_state_op(opcode, op, row)
     }
 }
 

--- a/evm_arithmetization/src/generation/state.rs
+++ b/evm_arithmetization/src/generation/state.rs
@@ -1,26 +1,217 @@
 use std::collections::HashMap;
 
+use anyhow::bail;
 use ethereum_types::{Address, BigEndianHash, H160, H256, U256};
 use keccak_hash::keccak;
+use log::log_enabled;
 use plonky2::field::types::Field;
 
 use super::mpt::{load_all_mpts, TrieRootPtrs};
 use super::TrieInputs;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
+use crate::cpu::membus::NUM_GP_CHANNELS;
+use crate::cpu::stack::MAX_USER_STACK_SIZE;
 use crate::generation::rlp::all_rlp_prover_inputs_reversed;
+use crate::generation::CpuColumnsView;
 use crate::generation::GenerationInputs;
 use crate::memory::segments::Segment;
 use crate::util::u256_to_usize;
 use crate::witness::errors::ProgramError;
-use crate::witness::memory::{MemoryAddress, MemoryState};
+use crate::witness::memory::MemoryChannel::GeneralPurpose;
+use crate::witness::memory::MemoryOpKind;
+use crate::witness::memory::{MemoryAddress, MemoryOp, MemoryState};
+use crate::witness::operation::{generate_exception, Operation};
 use crate::witness::state::RegistersState;
 use crate::witness::traces::{TraceCheckpoint, Traces};
-use crate::witness::util::stack_peek;
+use crate::witness::transition::{
+    decode, fill_op_flag, get_op_special_length, log_kernel_instruction, might_overflow_op,
+    perform_state_op, read_code_memory, Transition,
+};
+use crate::witness::util::{
+    fill_channel_with_value, mem_read_gp_with_log_and_fill, stack_peek, stack_pop_with_log_and_fill,
+};
 
-pub(crate) struct GenerationStateCheckpoint {
-    pub(crate) registers: RegistersState,
-    pub(crate) traces: TraceCheckpoint,
+/// A State is either an `Interpreter` (used for tests and jumpdest analysis) or
+/// a `GenerationState`.
+pub(crate) trait State<F: Field> {
+    /// Returns a `State`'s `Checkpoint`.
+    fn checkpoint(&mut self) -> GenerationStateCheckpoint;
+
+    /// Increments the `gas_used` register by a value `n`.
+    fn incr_gas(&mut self, n: u64);
+
+    /// Increments the `program_counter` register by a value `n`.
+    fn incr_pc(&mut self, n: usize);
+
+    /// Returns a `State`'s registers.
+    fn get_registers(&self) -> RegistersState;
+
+    /// Returns a `State`'s mutable registers.
+    fn get_mut_registers(&mut self) -> &mut RegistersState;
+
+    /// Returns the value stored at address `address` in a `State`.
+    fn get_from_memory(&mut self, address: MemoryAddress) -> U256;
+
+    /// Returns a mutable `GenerationState` from a `State`.
+    fn get_mut_generation_state(&mut self) -> &mut GenerationState<F>;
+
+    /// Returns true if a `State` is a `GenerationState` and false otherwise.
+    fn is_generation_state(&mut self) -> bool;
+
+    /// Increments the clock of an `Interpreter`'s clock.
+    fn incr_interpreter_clock(&mut self);
+
+    /// Returns the value of a `State`'s clock.
+    fn get_clock(&mut self) -> usize;
+
+    /// Rolls back a `State`.
+    fn rollback(&mut self, checkpoint: GenerationStateCheckpoint);
+
+    /// Returns a `State`'s stack.
+    fn get_stack(&mut self) -> Vec<U256>;
+
+    /// Returns the current context.
+    fn get_context(&mut self) -> usize;
+
+    fn get_halt_context(&mut self) -> Option<usize>;
+
+    /// Returns the content of a the `KernelGeneral` segment of a `State`.
+    fn mem_get_kernel_content(&self) -> Vec<Option<U256>>;
+
+    /// Applies a `State`'s operations since a checkpoint.
+    fn apply_ops(&mut self, checkpoint: GenerationStateCheckpoint);
+
+    /// Return the offsets at which execution must halt
+    fn get_halt_offsets(&self) -> Vec<usize>;
+
+    /// Simulates a CPU. It only generates the traces if the `State` is a
+    /// `GenerationState`. Otherwise, it simply simulates all ooperations.
+    fn run_cpu(&mut self, is_generation: bool) -> anyhow::Result<()> {
+        let halt_offsets = self.get_halt_offsets();
+
+        loop {
+            // If we've reached the kernel's halt routine.
+            let registers = self.get_registers();
+            let pc = registers.program_counter;
+
+            let halt = registers.is_kernel && halt_offsets.contains(&pc);
+
+            if halt {
+                if let Some(halt_context) = self.get_halt_context() {
+                    if registers.context == halt_context {
+                        // Only happens during jumpdest analysis.
+                        return Ok(());
+                    }
+                } else {
+                    if is_generation {
+                        log::info!("CPU halted after {} cycles", self.get_clock());
+                    }
+                    return Ok(());
+                }
+            }
+
+            self.transition()?;
+            self.incr_interpreter_clock();
+        }
+
+        Ok(())
+    }
+
+    fn handle_error(&mut self, err: ProgramError) -> anyhow::Result<()> {
+        let exc_code: u8 = match err {
+            ProgramError::OutOfGas => 0,
+            ProgramError::InvalidOpcode => 1,
+            ProgramError::StackUnderflow => 2,
+            ProgramError::InvalidJumpDestination => 3,
+            ProgramError::InvalidJumpiDestination => 4,
+            ProgramError::StackOverflow => 5,
+            _ => bail!("TODO: figure out what to do with this..."),
+        };
+
+        let (checkpoint, is_generation) = (self.checkpoint(), self.is_generation_state());
+
+        let (row, _) = self.base_row();
+        generate_exception(
+            exc_code,
+            self.get_mut_generation_state(),
+            row,
+            is_generation,
+        );
+
+        // We only clear traces for the interpreter
+        if !self.is_generation_state() {
+            self.clear_traces()
+        }
+
+        self.apply_ops(checkpoint);
+
+        Ok(())
+    }
+
+    fn transition(&mut self) -> anyhow::Result<()> {
+        let checkpoint = self.checkpoint();
+        let result = self.try_perform_instruction();
+
+        match result {
+            Ok(op) => {
+                self.apply_ops(checkpoint);
+
+                if might_overflow_op(op) {
+                    self.get_mut_registers().check_overflow = true;
+                }
+                Ok(())
+            }
+            Err(e) => {
+                if self.get_registers().is_kernel {
+                    let offset_name = KERNEL.offset_name(self.get_registers().program_counter);
+                    bail!(
+                        "{:?} in kernel at pc={}, stack={:?}, memory={:?}",
+                        e,
+                        offset_name,
+                        self.get_stack(),
+                        self.mem_get_kernel_content(),
+                    );
+                }
+                self.rollback(checkpoint);
+                self.handle_error(e)
+            }
+        }
+    }
+
+    /// Clears all traces from `GenerationState` except for
+    /// memory_ops, which are necessary to apply operations.
+    fn clear_traces(&mut self) {
+        let generation_state = self.get_mut_generation_state();
+        generation_state.traces.arithmetic_ops = vec![];
+        generation_state.traces.arithmetic_ops = vec![];
+        generation_state.traces.byte_packing_ops = vec![];
+        generation_state.traces.cpu = vec![];
+        generation_state.traces.logic_ops = vec![];
+        generation_state.traces.keccak_inputs = vec![];
+        generation_state.traces.keccak_sponge_ops = vec![];
+    }
+
+    fn try_perform_instruction(&mut self) -> Result<Operation, ProgramError>;
+
+    /// Row that has the correct values for system registers and the code
+    /// channel, but is otherwise blank. It fulfills the constraints that
+    /// are common to successful operations and the exception operation. It
+    /// also returns the opcode
+    fn base_row(&mut self) -> (CpuColumnsView<F>, u8) {
+        let generation_state = self.get_mut_generation_state();
+        let mut row: CpuColumnsView<F> = CpuColumnsView::default();
+        row.clock = F::from_canonical_usize(generation_state.traces.clock());
+        row.context = F::from_canonical_usize(generation_state.registers.context);
+        row.program_counter = F::from_canonical_usize(generation_state.registers.program_counter);
+        row.is_kernel_mode = F::from_bool(generation_state.registers.is_kernel);
+        row.gas = F::from_canonical_u64(generation_state.registers.gas_used);
+        row.stack_len = F::from_canonical_usize(generation_state.registers.stack_len);
+        fill_channel_with_value(&mut row, 0, generation_state.registers.stack_top);
+
+        let opcode = read_code_memory(generation_state, &mut row);
+        (row, opcode)
+    }
 }
 
 #[derive(Debug)]
@@ -161,13 +352,6 @@ impl<F: Field> GenerationState<F> {
         Ok(())
     }
 
-    pub(crate) fn checkpoint(&self) -> GenerationStateCheckpoint {
-        GenerationStateCheckpoint {
-            registers: self.registers,
-            traces: self.traces.checkpoint(),
-        }
-    }
-
     pub(crate) fn rollback(&mut self, checkpoint: GenerationStateCheckpoint) {
         self.registers = checkpoint.registers;
         self.traces.rollback(checkpoint.traces);
@@ -199,6 +383,195 @@ impl<F: Field> GenerationState<F> {
             jumpdest_table: None,
         }
     }
+}
+
+impl<F: Field> State<F> for GenerationState<F> {
+    fn checkpoint(&mut self) -> GenerationStateCheckpoint {
+        GenerationStateCheckpoint {
+            registers: self.registers,
+            traces: self.traces.checkpoint(),
+        }
+    }
+
+    /// Increments the `gas_used` register by a value `n`.
+    fn incr_gas(&mut self, n: u64) {
+        self.registers.gas_used += n;
+    }
+
+    /// Increments the `program_counter` register by a value `n`.
+    fn incr_pc(&mut self, n: usize) {
+        self.registers.program_counter += n;
+    }
+
+    /// Returns a `State`'s registers.
+    fn get_registers(&self) -> RegistersState {
+        self.registers
+    }
+
+    /// Returns a `State`'s mutable registers.
+    fn get_mut_registers(&mut self) -> &mut RegistersState {
+        &mut self.registers
+    }
+
+    /// Returns the value stored at address `address` in a `State`.
+    fn get_from_memory(&mut self, address: MemoryAddress) -> U256 {
+        self.memory.get(address, false, &HashMap::default())
+    }
+
+    /// Returns a mutable `GenerationState` from a `State`.
+    fn get_mut_generation_state(&mut self) -> &mut GenerationState<F> {
+        self
+    }
+
+    /// Returns true if a `State` is a `GenerationState` and false otherwise.
+    fn is_generation_state(&mut self) -> bool {
+        true
+    }
+
+    /// Increments the clock of an `Interpreter`'s clock.
+    fn incr_interpreter_clock(&mut self) {}
+
+    /// Returns the value of a `State`'s clock.
+    fn get_clock(&mut self) -> usize {
+        self.traces.clock()
+    }
+
+    /// Rolls back a `State`.
+    fn rollback(&mut self, checkpoint: GenerationStateCheckpoint) {
+        self.rollback(checkpoint)
+    }
+
+    /// Returns a `State`'s stack.
+    fn get_stack(&mut self) -> Vec<U256> {
+        self.stack()
+    }
+
+    fn get_context(&mut self) -> usize {
+        self.registers.context
+    }
+
+    fn get_halt_context(&mut self) -> Option<usize> {
+        None
+    }
+
+    /// Returns the content of a the `KernelGeneral` segment of a `State`.
+    fn mem_get_kernel_content(&self) -> Vec<Option<U256>> {
+        self.memory.contexts[0].segments[Segment::KernelGeneral.unscale()]
+            .content
+            .clone()
+    }
+
+    /// Applies a `State`'s operations since a checkpoint.
+    fn apply_ops(&mut self, checkpoint: GenerationStateCheckpoint) {
+        self.memory
+            .apply_ops(self.traces.mem_ops_since(checkpoint.traces))
+    }
+
+    fn get_halt_offsets(&self) -> Vec<usize> {
+        vec![KERNEL.global_labels["halt"]]
+    }
+
+    fn try_perform_instruction(&mut self) -> Result<Operation, ProgramError> {
+        let registers = self.registers;
+        let (mut row, opcode) = self.base_row();
+
+        let op = decode(registers, opcode)?;
+
+        if registers.is_kernel {
+            log_kernel_instruction(self, op);
+        } else {
+            log::debug!("User instruction: {:?}", op);
+        }
+        fill_op_flag(op, &mut row);
+
+        self.fill_stack_fields(&mut row)?;
+
+        // Might write in general CPU columns when it shouldn't, but the correct values
+        // will overwrite these ones during the op generation.
+        if let Some(special_len) = get_op_special_length(op) {
+            let special_len_f = F::from_canonical_usize(special_len);
+            let diff = row.stack_len - special_len_f;
+            if let Some(inv) = diff.try_inverse() {
+                row.general.stack_mut().stack_inv = inv;
+                row.general.stack_mut().stack_inv_aux = F::ONE;
+                self.registers.is_stack_top_read = true;
+            } else if (self.stack().len() != special_len) {
+                // If the `State` is an interpreter, we cannot rely on the row to carry out the
+                // check.
+                self.registers.is_stack_top_read = true;
+            }
+        } else if let Some(inv) = row.stack_len.try_inverse() {
+            row.general.stack_mut().stack_inv = inv;
+            row.general.stack_mut().stack_inv_aux = F::ONE;
+        }
+
+        perform_state_op(self, opcode, op, row)
+    }
+}
+
+impl<F: Field> Transition<F> for GenerationState<F> {
+    fn skip_if_necessary(&mut self, op: Operation) -> Result<Operation, ProgramError> {
+        Ok(op)
+    }
+
+    fn get_preinitialized_segments(
+        &self,
+    ) -> HashMap<Segment, crate::witness::memory::MemorySegmentState> {
+        HashMap::default()
+    }
+
+    fn generate_jumpdest_analysis(&mut self, dst: usize) -> bool {
+        false
+    }
+
+    fn fill_stack_fields(&mut self, row: &mut CpuColumnsView<F>) -> Result<(), ProgramError> {
+        if self.registers.is_stack_top_read {
+            let channel = &mut row.mem_channels[0];
+            channel.used = F::ONE;
+            channel.is_read = F::ONE;
+            channel.addr_context = F::from_canonical_usize(self.registers.context);
+            channel.addr_segment = F::from_canonical_usize(Segment::Stack.unscale());
+            channel.addr_virtual = F::from_canonical_usize(self.registers.stack_len - 1);
+
+            let address = MemoryAddress::new(
+                self.registers.context,
+                Segment::Stack,
+                self.registers.stack_len - 1,
+            );
+
+            let mem_op = MemoryOp::new(
+                GeneralPurpose(0),
+                self.traces.clock(),
+                address,
+                MemoryOpKind::Read,
+                self.registers.stack_top,
+            );
+            self.traces.push_memory(mem_op);
+        }
+        self.registers.is_stack_top_read = false;
+
+        if self.registers.check_overflow {
+            if self.registers.is_kernel {
+                row.general.stack_mut().stack_len_bounds_aux = F::ZERO;
+            } else {
+                let clock = self.traces.clock();
+                let last_row = &mut self.traces.cpu[clock - 1];
+                let disallowed_len = F::from_canonical_usize(MAX_USER_STACK_SIZE + 1);
+                let diff = row.stack_len - disallowed_len;
+                if let Some(inv) = diff.try_inverse() {
+                    last_row.general.stack_mut().stack_len_bounds_aux = inv;
+                }
+            }
+        }
+        self.registers.check_overflow = false;
+
+        Ok(())
+    }
+}
+
+pub(crate) struct GenerationStateCheckpoint {
+    pub(crate) registers: RegistersState,
+    pub(crate) traces: TraceCheckpoint,
 }
 
 /// Withdrawals prover input array is of the form `[addr0, amount0, ..., addrN,

--- a/evm_arithmetization/src/witness/memory.rs
+++ b/evm_arithmetization/src/witness/memory.rs
@@ -288,7 +288,7 @@ impl MemoryState {
     /// is part of the `preinitialize_segments`.
     pub(crate) fn is_preinitialized_segment(&self, segment: usize) -> bool {
         if let Some(seg) = Segment::all().get(segment) {
-            self.preinitialized_segments.contains_key(&seg)
+            self.preinitialized_segments.contains_key(seg)
         } else {
             false
         }

--- a/evm_arithmetization/src/witness/memory.rs
+++ b/evm_arithmetization/src/witness/memory.rs
@@ -223,7 +223,6 @@ impl MemoryState {
     pub(crate) fn get(
         &self,
         address: MemoryAddress,
-        is_interpreter: bool,
         preinitialized_segments: &HashMap<Segment, MemorySegmentState, RandomState>,
     ) -> U256 {
         match self.get_option(address) {
@@ -271,7 +270,6 @@ impl MemoryState {
     pub(crate) fn read_global_metadata(&self, field: GlobalMetadata) -> U256 {
         self.get(
             MemoryAddress::new_bundle(U256::from(field as usize)).unwrap(),
-            false,
             &HashMap::default(),
         )
     }

--- a/evm_arithmetization/src/witness/operation.rs
+++ b/evm_arithmetization/src/witness/operation.rs
@@ -7,6 +7,7 @@ use keccak_hash::keccak;
 use plonky2::field::types::Field;
 
 use super::memory::MemorySegmentState;
+use super::transition::Transition;
 use super::util::{
     byte_packing_log, byte_unpacking_log, mem_read_with_log, mem_write_log,
     mem_write_partial_log_and_fill, push_no_write, push_with_write,
@@ -21,14 +22,13 @@ use crate::cpu::simple_logic::eq_iszero::generate_pinv_diff;
 use crate::cpu::stack::MAX_USER_STACK_SIZE;
 use crate::extension_tower::BN_BASE;
 use crate::generation::state::GenerationState;
-use crate::generation::State;
+use crate::generation::state::State;
 use crate::memory::segments::Segment;
 use crate::util::u256_to_usize;
 use crate::witness::errors::MemoryError::VirtTooLarge;
 use crate::witness::errors::ProgramError;
 use crate::witness::memory::{MemoryAddress, MemoryChannel, MemoryOp, MemoryOpKind};
 use crate::witness::operation::MemoryChannel::GeneralPurpose;
-use crate::witness::transition::fill_stack_fields;
 use crate::witness::util::{
     keccak_sponge_log, mem_read_gp_with_log_and_fill, mem_write_gp_log_and_fill,
     stack_pop_with_log_and_fill,
@@ -214,160 +214,6 @@ pub(crate) fn generate_pop<F: Field>(
 
     state.traces.push_cpu(row);
 
-    Ok(())
-}
-
-pub(crate) fn generate_jump<F: Field>(
-    state: &mut State<F>,
-    mut row: CpuColumnsView<F>,
-    is_jumpdest_analysis: bool,
-) -> Result<(), ProgramError> {
-    let [(dst, _)] =
-        stack_pop_with_log_and_fill::<1, _>(state.get_mut_generation_state(), &mut row)?;
-
-    let dst: u32 = dst
-        .try_into()
-        .map_err(|_| ProgramError::InvalidJumpDestination)?;
-
-    if is_jumpdest_analysis {
-        match state {
-            State::Generation(state) => {
-                panic!("Cannot carry out jumpdest analysis with a `GenerationState.")
-            }
-            State::Interpreter(interpreter) => {
-                if !interpreter.generation_state.registers.is_kernel {
-                    interpreter.add_jumpdest_offset(dst as usize);
-                }
-            }
-        }
-    } else {
-        let gen_state = state.get_mut_generation_state();
-        // Even though we might be in the interpreter, `JumpdestBits` is not part of the
-        // preinitialized segments, so we don't need to carry out the additional checks
-        // when get the value from memory.
-        let (jumpdest_bit, jumpdest_bit_log) = mem_read_gp_with_log_and_fill(
-            NUM_GP_CHANNELS - 1,
-            MemoryAddress::new(
-                gen_state.registers.context,
-                Segment::JumpdestBits,
-                dst as usize,
-            ),
-            gen_state,
-            &mut row,
-            false,
-            &HashMap::default(),
-        );
-
-        row.mem_channels[1].value[0] = F::ONE;
-
-        if gen_state.registers.is_kernel {
-            // Don't actually do the read, just set the address, etc.
-            let channel = &mut row.mem_channels[NUM_GP_CHANNELS - 1];
-            channel.used = F::ZERO;
-            channel.value[0] = F::ONE;
-        } else {
-            if jumpdest_bit != U256::one() {
-                return Err(ProgramError::InvalidJumpDestination);
-            }
-            gen_state.traces.push_memory(jumpdest_bit_log);
-        }
-
-        // Extra fields required by the constraints.
-        row.general.jumps_mut().should_jump = F::ONE;
-        row.general.jumps_mut().cond_sum_pinv = F::ONE;
-
-        let diff = row.stack_len - F::ONE;
-        if let Some(inv) = diff.try_inverse() {
-            row.general.stack_mut().stack_inv = inv;
-            row.general.stack_mut().stack_inv_aux = F::ONE;
-        } else {
-            row.general.stack_mut().stack_inv = F::ZERO;
-            row.general.stack_mut().stack_inv_aux = F::ZERO;
-        }
-
-        gen_state.traces.push_cpu(row);
-    }
-    state.get_mut_generation_state().jump_to(dst as usize)?;
-    Ok(())
-}
-
-pub(crate) fn generate_jumpi<F: Field>(
-    state: &mut State<F>,
-    mut row: CpuColumnsView<F>,
-    is_jumpdest_analysis: bool,
-) -> Result<(), ProgramError> {
-    let [(dst, _), (cond, log_cond)] =
-        stack_pop_with_log_and_fill::<2, _>(state.get_mut_generation_state(), &mut row)?;
-
-    let should_jump = !cond.is_zero();
-    if should_jump {
-        let dst: u32 = dst
-            .try_into()
-            .map_err(|_| ProgramError::InvalidJumpiDestination)?;
-        let is_kernel = state.get_registers().is_kernel;
-        if is_jumpdest_analysis && !is_kernel {
-            match state {
-                State::Generation(state) => {
-                    panic!("Cannot carry out jumpdest analysis with a `GenerationState`.")
-                }
-                State::Interpreter(interpreter) => interpreter.add_jumpdest_offset(dst as usize),
-            }
-        } else {
-            row.general.jumps_mut().should_jump = F::ONE;
-            let cond_sum_u64 = cond
-                .0
-                .into_iter()
-                .map(|limb| ((limb as u32) as u64) + (limb >> 32))
-                .sum();
-            let cond_sum = F::from_canonical_u64(cond_sum_u64);
-            row.general.jumps_mut().cond_sum_pinv = cond_sum.inverse();
-        }
-        state.get_mut_generation_state().jump_to(dst as usize)?;
-    } else {
-        row.general.jumps_mut().should_jump = F::ZERO;
-        row.general.jumps_mut().cond_sum_pinv = F::ZERO;
-        state.incr_pc(1);
-    }
-
-    let gen_state = state.get_mut_generation_state();
-    // Even though we might be in the interpreter, `JumpdestBits` is not part of the
-    // preinitialized segments, so we don't need to carry out the additional checks
-    // when get the value from memory.
-    let (jumpdest_bit, jumpdest_bit_log) = mem_read_gp_with_log_and_fill(
-        NUM_GP_CHANNELS - 1,
-        MemoryAddress::new(
-            gen_state.registers.context,
-            Segment::JumpdestBits,
-            dst.low_u32() as usize,
-        ),
-        gen_state,
-        &mut row,
-        false,
-        &HashMap::default(),
-    );
-    if !should_jump || gen_state.registers.is_kernel {
-        // Don't actually do the read, just set the address, etc.
-        let channel = &mut row.mem_channels[NUM_GP_CHANNELS - 1];
-        channel.used = F::ZERO;
-        channel.value[0] = F::ONE;
-    } else {
-        if jumpdest_bit != U256::one() {
-            return Err(ProgramError::InvalidJumpiDestination);
-        }
-        gen_state.traces.push_memory(jumpdest_bit_log);
-    }
-
-    let diff = row.stack_len - F::TWO;
-    if let Some(inv) = diff.try_inverse() {
-        row.general.stack_mut().stack_inv = inv;
-        row.general.stack_mut().stack_inv_aux = F::ONE;
-    } else {
-        row.general.stack_mut().stack_inv = F::ZERO;
-        row.general.stack_mut().stack_inv_aux = F::ZERO;
-    }
-
-    gen_state.traces.push_memory(log_cond);
-    gen_state.traces.push_cpu(row);
     Ok(())
 }
 
@@ -1009,32 +855,37 @@ pub(crate) fn generate_mstore_general<F: Field>(
     Ok(())
 }
 
-pub(crate) fn generate_mstore_32bytes<F: Field>(
+pub(crate) fn generate_mstore_32bytes<F: Field, S: State<F>>(
     n: u8,
-    state: &mut GenerationState<F>,
+    state: &mut S,
     mut row: CpuColumnsView<F>,
 ) -> Result<(), ProgramError> {
-    let [(addr, _), (val, log_in1)] = stack_pop_with_log_and_fill::<2, _>(state, &mut row)?;
+    let generation_state = state.get_mut_generation_state();
+    let [(addr, _), (val, log_in1)] =
+        stack_pop_with_log_and_fill::<2, _>(generation_state, &mut row)?;
 
     let base_address = MemoryAddress::new_bundle(addr)?;
 
-    byte_unpacking_log(state, base_address, val, n as usize);
+    byte_unpacking_log(generation_state, base_address, val, n as usize);
 
     let new_addr = addr + n;
-    push_no_write(state, new_addr);
+    push_no_write(generation_state, new_addr);
 
-    state.traces.push_memory(log_in1);
-    state.traces.push_cpu(row);
+    generation_state.traces.push_memory(log_in1);
+    generation_state.traces.push_cpu(row);
     Ok(())
 }
 
-pub(crate) fn generate_exception<F: Field>(
+pub(crate) fn generate_exception<F: Field, T: Transition<F>>(
     exc_code: u8,
-    state: &mut GenerationState<F>,
+    state: &mut T,
     mut row: CpuColumnsView<F>,
     is_generation: bool,
 ) -> Result<(), ProgramError> {
-    if TryInto::<u32>::try_into(state.registers.gas_used).is_err() {
+    // TDO: se fue arriba
+    state.fill_stack_fields(&mut row)?;
+    let generation_state = state.get_mut_generation_state();
+    if TryInto::<u32>::try_into(generation_state.registers.gas_used).is_err() {
         return Err(ProgramError::GasLimitError);
     }
 
@@ -1044,8 +895,6 @@ pub(crate) fn generate_exception<F: Field>(
         row.general.stack_mut().stack_inv = inv;
         row.general.stack_mut().stack_inv_aux = F::ONE;
     }
-
-    fill_stack_fields(state, &mut row, is_generation)?;
 
     row.general.exception_mut().exc_code_bits = [
         F::from_bool(exc_code & 1 != 0),
@@ -1067,7 +916,9 @@ pub(crate) fn generate_exception<F: Field>(
             // Even though we might be in the interpreter, `Code` is not part of the
             // preinitialized segments, so we don't need to carry out the additional checks
             // when get the value from memory.
-            let val = state.memory.get(address, false, &HashMap::default());
+            let val = generation_state
+                .memory
+                .get(address, false, &HashMap::default());
             val.low_u32() as u8
         })
         .collect_vec();
@@ -1081,20 +932,26 @@ pub(crate) fn generate_exception<F: Field>(
     jumptable_channel.addr_virtual = F::from_canonical_usize(handler_addr_addr);
     jumptable_channel.value[0] = F::from_canonical_usize(u256_to_usize(packed_int)?);
 
-    byte_packing_log(state, base_address, bytes);
+    byte_packing_log(generation_state, base_address, bytes);
     let new_program_counter = u256_to_usize(packed_int)?;
 
-    let gas = U256::from(state.registers.gas_used);
+    let gas = U256::from(generation_state.registers.gas_used);
 
-    let exc_info = U256::from(state.registers.program_counter) + (gas << 192);
+    let exc_info = U256::from(generation_state.registers.program_counter) + (gas << 192);
 
     // Get the opcode so we can provide it to the range_check operation.
-    let code_context = state.registers.code_context();
-    let address = MemoryAddress::new(code_context, Segment::Code, state.registers.program_counter);
+    let code_context = generation_state.registers.code_context();
+    let address = MemoryAddress::new(
+        code_context,
+        Segment::Code,
+        generation_state.registers.program_counter,
+    );
     // Even though we might be in the interpreter, `Code` is not part of the
     // preinitialized segments, so we don't need to carry out the additional checks
     // when get the value from memory.
-    let opcode = state.memory.get(address, false, &HashMap::default());
+    let opcode = generation_state
+        .memory
+        .get(address, false, &HashMap::default());
 
     // `ArithmeticStark` range checks `mem_channels[0]`, which contains
     // the top of the stack, `mem_channels[1]`, which contains the new PC,
@@ -1103,7 +960,7 @@ pub(crate) fn generate_exception<F: Field>(
     // Our goal here is to range-check the gas, contained in syscall_info,
     // stored in the next stack top.
     let range_check_op = arithmetic::Operation::range_check(
-        state.registers.stack_top,
+        generation_state.registers.stack_top,
         packed_int,
         U256::from(0),
         opcode,
@@ -1113,15 +970,15 @@ pub(crate) fn generate_exception<F: Field>(
     // kernel mode so we can't incorrectly trigger a stack overflow. However,
     // note that we have to do it _after_ we make `exc_info`, which should
     // contain the old values.
-    state.registers.program_counter = new_program_counter;
-    state.registers.is_kernel = true;
-    state.registers.gas_used = 0;
+    generation_state.registers.program_counter = new_program_counter;
+    generation_state.registers.is_kernel = true;
+    generation_state.registers.gas_used = 0;
 
-    push_with_write(state, &mut row, exc_info)?;
+    push_with_write(generation_state, &mut row, exc_info)?;
 
     log::debug!("Exception to {}", KERNEL.offset_name(new_program_counter));
-    state.traces.push_arithmetic(range_check_op);
-    state.traces.push_cpu(row);
+    generation_state.traces.push_arithmetic(range_check_op);
+    generation_state.traces.push_cpu(row);
 
     Ok(())
 }

--- a/evm_arithmetization/src/witness/operation.rs
+++ b/evm_arithmetization/src/witness/operation.rs
@@ -855,7 +855,6 @@ pub(crate) fn generate_exception<F: Field, T: Transition<F>>(
     state: &mut T,
     mut row: CpuColumnsView<F>,
 ) -> Result<(), ProgramError> {
-    // TDO: se fue arriba
     state.fill_stack_fields(&mut row)?;
     let generation_state = state.get_mut_generation_state();
     if TryInto::<u32>::try_into(generation_state.registers.gas_used).is_err() {

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -1,21 +1,27 @@
 use std::collections::HashMap;
+use std::hash::RandomState;
 
 use anyhow::bail;
+use ethereum_types::U256;
 use log::log_enabled;
 use plonky2::field::types::Field;
 
-use super::memory::{MemoryOp, MemoryOpKind};
-use super::util::fill_channel_with_value;
+use super::memory::{MemoryOp, MemoryOpKind, MemorySegmentState};
+use super::util::{
+    fill_channel_with_value, mem_read_gp_with_log_and_fill, push_no_write,
+    stack_pop_with_log_and_fill,
+};
 use crate::cpu::columns::CpuColumnsView;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::interpreter::InterpreterMemOpKind;
+use crate::cpu::membus::NUM_GP_CHANNELS;
 use crate::cpu::stack::{
     EQ_STACK_BEHAVIOR, IS_ZERO_STACK_BEHAVIOR, JUMPI_OP, JUMP_OP, MAX_USER_STACK_SIZE,
     MIGHT_OVERFLOW, STACK_BEHAVIORS,
 };
-use crate::generation::state::{GenerationState, GenerationStateCheckpoint};
-use crate::generation::State;
+use crate::extension_tower::BN_BASE;
+use crate::generation::state::{GenerationState, GenerationStateCheckpoint, State};
 use crate::memory::segments::Segment;
 use crate::witness::errors::ProgramError;
 use crate::witness::gas::gas_to_charge;
@@ -26,7 +32,10 @@ use crate::witness::state::RegistersState;
 use crate::witness::util::mem_read_code_with_log_and_fill;
 use crate::{arithmetic, logic};
 
-fn read_code_memory<F: Field>(state: &mut GenerationState<F>, row: &mut CpuColumnsView<F>) -> u8 {
+pub(crate) fn read_code_memory<F: Field>(
+    state: &mut GenerationState<F>,
+    row: &mut CpuColumnsView<F>,
+) -> u8 {
     let code_context = state.registers.code_context();
     row.code_context = F::from_canonical_usize(code_context);
 
@@ -163,7 +172,7 @@ pub(crate) fn decode(registers: RegistersState, opcode: u8) -> Result<Operation,
     }
 }
 
-fn fill_op_flag<F: Field>(op: Operation, row: &mut CpuColumnsView<F>) {
+pub(crate) fn fill_op_flag<F: Field>(op: Operation, row: &mut CpuColumnsView<F>) {
     let flags = &mut row.op;
     *match op {
         Operation::Dup(_) | Operation::Swap(_) => &mut flags.dup_swap,
@@ -191,7 +200,7 @@ fn fill_op_flag<F: Field>(op: Operation, row: &mut CpuColumnsView<F>) {
 
 // Equal to the number of pops if an operation pops without pushing, and `None`
 // otherwise.
-const fn get_op_special_length(op: Operation) -> Option<usize> {
+pub(crate) const fn get_op_special_length(op: Operation) -> Option<usize> {
     let behavior_opt = match op {
         Operation::Push(0) | Operation::Pc => STACK_BEHAVIORS.pc_push0,
         Operation::Push(1..) | Operation::ProverInput => STACK_BEHAVIORS.push_prover_input,
@@ -232,7 +241,7 @@ const fn get_op_special_length(op: Operation) -> Option<usize> {
 // These operations might trigger a stack overflow, typically those pushing
 // without popping. Kernel-only pushing instructions aren't considered; they
 // can't overflow.
-const fn might_overflow_op(op: Operation) -> bool {
+pub(crate) const fn might_overflow_op(op: Operation) -> bool {
     match op {
         Operation::Push(1..) | Operation::ProverInput => MIGHT_OVERFLOW.push_prover_input,
         Operation::Dup(_) | Operation::Swap(_) => MIGHT_OVERFLOW.dup_swap,
@@ -259,116 +268,13 @@ const fn might_overflow_op(op: Operation) -> bool {
     }
 }
 
-fn perform_op<F: Field>(
-    any_state: &mut State<F>,
-    op: Operation,
-    opcode: u8,
-    row: CpuColumnsView<F>,
-) -> Result<(), ProgramError> {
-    let (op, is_interpreter, preinitialized_segments, is_jumpdest_analysis) = match any_state {
-        State::Generation(state) => (op, false, HashMap::default(), false),
-        State::Interpreter(interpreter) => {
-            // Jumpdest analysis is performed natively by the interpreter and not
-            // using the non-deterministic Kernel assembly code.
-            let op = if interpreter.is_kernel()
-                && interpreter.is_jumpdest_analysis
-                && interpreter.generation_state.registers.program_counter
-                    == KERNEL.global_labels["jumpdest_analysis"]
-            {
-                interpreter.generation_state.registers.program_counter =
-                    KERNEL.global_labels["jumpdest_analysis_end"];
-                interpreter
-                    .generation_state
-                    .set_jumpdest_bits(&interpreter.generation_state.get_current_code()?);
-                let opcode = interpreter
-                    .code()
-                    .get(interpreter.generation_state.registers.program_counter)
-                    .byte(0);
-
-                decode(interpreter.generation_state.registers, opcode)?
-            } else {
-                op
-            };
-            (
-                op,
-                true,
-                interpreter.preinitialized_segments.clone(),
-                interpreter.is_jumpdest_analysis,
-            )
-        }
-    };
-
-    #[cfg(debug_assertions)]
-    if !any_state.get_registers().is_kernel {
-        log::debug!(
-            "User instruction {:?}, stack = {:?}, ctx = {}",
-            op,
-            {
-                let mut stack = any_state.get_stack();
-                stack.reverse();
-                stack
-            },
-            any_state.get_registers().context
-        );
-    }
-
-    let state = any_state.get_mut_generation_state();
-
-    match op {
-        Operation::Push(n) => generate_push(n, state, row)?,
-        Operation::Dup(n) => generate_dup(n, state, row)?,
-        Operation::Swap(n) => generate_swap(n, state, row)?,
-        Operation::Iszero => generate_iszero(state, row)?,
-        Operation::Not => generate_not(state, row)?,
-        Operation::BinaryArithmetic(arithmetic::BinaryOperator::Shl) => generate_shl(state, row)?,
-        Operation::BinaryArithmetic(arithmetic::BinaryOperator::Shr) => generate_shr(state, row)?,
-        Operation::Syscall(opcode, stack_values_read, stack_len_increased) => {
-            generate_syscall(opcode, stack_values_read, stack_len_increased, state, row)?
-        }
-        Operation::Eq => generate_eq(state, row)?,
-        Operation::BinaryLogic(binary_logic_op) => {
-            generate_binary_logic_op(binary_logic_op, state, row)?
-        }
-        Operation::BinaryArithmetic(op) => generate_binary_arithmetic_op(op, state, row)?,
-        Operation::TernaryArithmetic(op) => generate_ternary_arithmetic_op(op, state, row)?,
-        Operation::KeccakGeneral => {
-            generate_keccak_general(state, row, is_interpreter, &preinitialized_segments)?
-        }
-        Operation::ProverInput => generate_prover_input(state, row)?,
-        Operation::Pop => generate_pop(state, row)?,
-        Operation::Jump => generate_jump(any_state, row, is_jumpdest_analysis)?,
-        Operation::Jumpi => generate_jumpi(any_state, row, is_jumpdest_analysis)?,
-        Operation::Pc => generate_pc(state, row)?,
-        Operation::Jumpdest => generate_jumpdest(state, row)?,
-        Operation::GetContext => generate_get_context(state, row)?,
-        Operation::SetContext => generate_set_context(state, row)?,
-        Operation::Mload32Bytes => {
-            generate_mload_32bytes(state, row, is_interpreter, &preinitialized_segments)?
-        }
-        Operation::Mstore32Bytes(n) => generate_mstore_32bytes(n, state, row)?,
-        Operation::ExitKernel => generate_exit_kernel(state, row)?,
-        Operation::MloadGeneral => {
-            generate_mload_general(state, row, is_interpreter, &preinitialized_segments)?
-        }
-        Operation::MstoreGeneral => generate_mstore_general(state, row)?,
-    };
-    match any_state {
-        State::Generation(state) => {}
-        State::Interpreter(interpreter) => {
-            interpreter.clear_traces();
-            interpreter.opcode_count[opcode as usize] += 1;
-        }
-    }
-    Ok(())
-}
-
-fn perform_state_op<F: Field>(
-    any_state: &mut State<F>,
+pub(crate) fn perform_state_op<F: Field, T: Transition<F>>(
+    any_state: &mut T,
     opcode: u8,
     op: Operation,
     row: CpuColumnsView<F>,
 ) -> Result<Operation, ProgramError> {
-    perform_op(any_state, op, opcode, row)?;
+    any_state.perform_op(op, opcode, row)?;
     any_state.incr_pc(match op {
         Operation::Syscall(_, _, _) | Operation::ExitKernel => 0,
         Operation::Push(n) => n as usize + 1,
@@ -399,121 +305,7 @@ fn perform_state_op<F: Field>(
     Ok(op)
 }
 
-/// Row that has the correct values for system registers and the code channel,
-/// but is otherwise blank. It fulfills the constraints that are common to
-/// successful operations and the exception operation. It also returns the
-/// opcode.
-fn base_row<F: Field>(state: &mut GenerationState<F>) -> (CpuColumnsView<F>, u8) {
-    let mut row: CpuColumnsView<F> = CpuColumnsView::default();
-    row.clock = F::from_canonical_usize(state.traces.clock());
-    row.context = F::from_canonical_usize(state.registers.context);
-    row.program_counter = F::from_canonical_usize(state.registers.program_counter);
-    row.is_kernel_mode = F::from_bool(state.registers.is_kernel);
-    row.gas = F::from_canonical_u64(state.registers.gas_used);
-    row.stack_len = F::from_canonical_usize(state.registers.stack_len);
-    fill_channel_with_value(&mut row, 0, state.registers.stack_top);
-
-    let opcode = read_code_memory(state, &mut row);
-    (row, opcode)
-}
-
-pub(crate) fn fill_stack_fields<F: Field>(
-    state: &mut GenerationState<F>,
-    row: &mut CpuColumnsView<F>,
-    is_generation: bool,
-) -> Result<(), ProgramError> {
-    if state.registers.is_stack_top_read && is_generation {
-        let channel = &mut row.mem_channels[0];
-        channel.used = F::ONE;
-        channel.is_read = F::ONE;
-        channel.addr_context = F::from_canonical_usize(state.registers.context);
-        channel.addr_segment = F::from_canonical_usize(Segment::Stack.unscale());
-        channel.addr_virtual = F::from_canonical_usize(state.registers.stack_len - 1);
-
-        let address = MemoryAddress::new(
-            state.registers.context,
-            Segment::Stack,
-            state.registers.stack_len - 1,
-        );
-
-        let mem_op = MemoryOp::new(
-            GeneralPurpose(0),
-            state.traces.clock(),
-            address,
-            MemoryOpKind::Read,
-            state.registers.stack_top,
-        );
-        state.traces.push_memory(mem_op);
-    }
-    state.registers.is_stack_top_read = false;
-
-    if state.registers.check_overflow && is_generation {
-        if state.registers.is_kernel {
-            row.general.stack_mut().stack_len_bounds_aux = F::ZERO;
-        } else {
-            let clock = state.traces.clock();
-            let last_row = &mut state.traces.cpu[clock - 1];
-            let disallowed_len = F::from_canonical_usize(MAX_USER_STACK_SIZE + 1);
-            let diff = row.stack_len - disallowed_len;
-            if let Some(inv) = diff.try_inverse() {
-                last_row.general.stack_mut().stack_len_bounds_aux = inv;
-            } else {
-                // This is a stack overflow that should have been caught earlier.
-                return Err(ProgramError::InterpreterError);
-            }
-        }
-    }
-    state.registers.check_overflow = false;
-
-    Ok(())
-}
-
-fn try_perform_instruction<F: Field>(any_state: &mut State<F>) -> Result<Operation, ProgramError> {
-    let is_generation = any_state.is_generation_state();
-    let registers = any_state.get_registers();
-
-    let state = any_state.get_mut_generation_state();
-    let (mut row, opcode) = base_row(state);
-
-    let op = decode(registers, opcode)?;
-
-    if registers.is_kernel {
-        log_kernel_instruction(state, op);
-    } else {
-        log::debug!("User instruction: {:?}", op);
-    }
-
-    if is_generation {
-        fill_op_flag(op, &mut row);
-    }
-
-    fill_stack_fields(state, &mut row, is_generation)?;
-
-    // Might write in general CPU columns when it shouldn't, but the correct values
-    // will overwrite these ones during the op generation.
-    if let Some(special_len) = get_op_special_length(op) {
-        let special_len_f = F::from_canonical_usize(special_len);
-        let diff = row.stack_len - special_len_f;
-        if let Some(inv) = diff.try_inverse()
-            && is_generation
-        {
-            row.general.stack_mut().stack_inv = inv;
-            row.general.stack_mut().stack_inv_aux = F::ONE;
-            state.registers.is_stack_top_read = true;
-        } else if !is_generation && (state.stack().len() != special_len) {
-            // If the `State` is an interpreter, we cannot rely on the row to carry out the
-            // check.
-            state.registers.is_stack_top_read = true;
-        }
-    } else if let Some(inv) = row.stack_len.try_inverse() {
-        row.general.stack_mut().stack_inv = inv;
-        row.general.stack_mut().stack_inv_aux = F::ONE;
-    }
-
-    perform_state_op(any_state, opcode, op, row)
-}
-
-fn log_kernel_instruction<F: Field>(state: &GenerationState<F>, op: Operation) {
+pub(crate) fn log_kernel_instruction<F: Field>(state: &mut GenerationState<F>, op: Operation) {
     // The logic below is a bit costly, so skip it if debug logs aren't enabled.
     if !log_enabled!(log::Level::Debug) {
         return;
@@ -542,68 +334,280 @@ fn log_kernel_instruction<F: Field>(state: &GenerationState<F>, op: Operation) {
     assert!(pc < KERNEL.code.len(), "Kernel PC is out of range: {}", pc);
 }
 
-fn handle_error<F: Field>(any_state: &mut State<F>, err: ProgramError) -> anyhow::Result<()> {
-    let exc_code: u8 = match err {
-        ProgramError::OutOfGas => 0,
-        ProgramError::InvalidOpcode => 1,
-        ProgramError::StackUnderflow => 2,
-        ProgramError::InvalidJumpDestination => 3,
-        ProgramError::InvalidJumpiDestination => 4,
-        ProgramError::StackOverflow => 5,
-        _ => bail!("TODO: figure out what to do with this..."),
-    };
+pub(crate) trait Transition<F: Field>: State<F> {
+    fn generate_jumpdest_analysis(&mut self, dst: usize) -> bool;
 
-    let (checkpoint, is_generation, state): (
-        GenerationStateCheckpoint,
-        bool,
-        &mut GenerationState<_>,
-    ) = match any_state {
-        State::Generation(state) => (state.checkpoint(), true, state),
-        State::Interpreter(interpreter) => (
-            interpreter.checkpoint(),
+    fn generate_jump(&mut self, mut row: CpuColumnsView<F>) -> Result<(), ProgramError> {
+        let [(dst, _)] =
+            stack_pop_with_log_and_fill::<1, _>(self.get_mut_generation_state(), &mut row)?;
+
+        let dst: u32 = dst
+            .try_into()
+            .map_err(|_| ProgramError::InvalidJumpDestination)?;
+
+        if !self.generate_jumpdest_analysis(dst as usize) {
+            let gen_state = self.get_mut_generation_state();
+            // Even though we might be in the interpreter, `JumpdestBits` is not part
+            // preinitialized segments, so we don't need to carry out the additional checks
+            // when get the value from memory.
+            let (jumpdest_bit, jumpdest_bit_log) = mem_read_gp_with_log_and_fill(
+                NUM_GP_CHANNELS - 1,
+                MemoryAddress::new(
+                    gen_state.registers.context,
+                    Segment::JumpdestBits,
+                    dst as usize,
+                ),
+                gen_state,
+                &mut row,
+                false,
+                &HashMap::default(),
+            );
+
+            row.mem_channels[1].value[0] = F::ONE;
+
+            if gen_state.registers.is_kernel {
+                // Don't actually do the read, just set the address, etc.
+                let channel = &mut row.mem_channels[NUM_GP_CHANNELS - 1];
+                channel.used = F::ZERO;
+                channel.value[0] = F::ONE;
+            } else {
+                if jumpdest_bit != U256::one() {
+                    return Err(ProgramError::InvalidJumpDestination);
+                }
+                gen_state.traces.push_memory(jumpdest_bit_log);
+            }
+
+            // Extra fields required by the constraints.
+            row.general.jumps_mut().should_jump = F::ONE;
+            row.general.jumps_mut().cond_sum_pinv = F::ONE;
+
+            let diff = row.stack_len - F::ONE;
+            if let Some(inv) = diff.try_inverse() {
+                row.general.stack_mut().stack_inv = inv;
+                row.general.stack_mut().stack_inv_aux = F::ONE;
+            } else {
+                row.general.stack_mut().stack_inv = F::ZERO;
+                row.general.stack_mut().stack_inv_aux = F::ZERO;
+            }
+
+            gen_state.traces.push_cpu(row);
+        }
+        self.get_mut_generation_state().jump_to(dst as usize)?;
+        Ok(())
+    }
+
+    fn generate_jumpi(&mut self, mut row: CpuColumnsView<F>) -> Result<(), ProgramError> {
+        let [(dst, _), (cond, log_cond)] =
+            stack_pop_with_log_and_fill::<2, _>(self.get_mut_generation_state(), &mut row)?;
+
+        let should_jump = !cond.is_zero();
+        if should_jump {
+            let dst: u32 = dst
+                .try_into()
+                .map_err(|_| ProgramError::InvalidJumpiDestination)?;
+            let is_kernel = self.get_registers().is_kernel;
+            if !self.generate_jumpdest_analysis(dst as usize) {
+                row.general.jumps_mut().should_jump = F::ONE;
+                let cond_sum_u64 = cond
+                    .0
+                    .into_iter()
+                    .map(|limb| ((limb as u32) as u64) + (limb >> 32))
+                    .sum();
+                let cond_sum = F::from_canonical_u64(cond_sum_u64);
+                row.general.jumps_mut().cond_sum_pinv = cond_sum.inverse();
+            }
+            self.get_mut_generation_state().jump_to(dst as usize)?;
+        } else {
+            row.general.jumps_mut().should_jump = F::ZERO;
+            row.general.jumps_mut().cond_sum_pinv = F::ZERO;
+            self.incr_pc(1);
+        }
+
+        let gen_state = self.get_mut_generation_state();
+        // Even though we might be in the interpreter, `JumpdestBits` is not part of the
+        // preinitialized segments, so we don't need to carry out the additional checks
+        // when get the value from memory.
+        let (jumpdest_bit, jumpdest_bit_log) = mem_read_gp_with_log_and_fill(
+            NUM_GP_CHANNELS - 1,
+            MemoryAddress::new(
+                gen_state.registers.context,
+                Segment::JumpdestBits,
+                dst.low_u32() as usize,
+            ),
+            gen_state,
+            &mut row,
             false,
-            &mut interpreter.generation_state,
-        ),
-    };
-    let (row, _) = base_row(state);
-    generate_exception(exc_code, state, row, is_generation);
-    match any_state {
-        State::Generation(state) => {}
-        // If we are in the interpreter, we do not need all the traces. We only need the memory
-        // traces of the current operation.
-        State::Interpreter(interpreter) => interpreter.clear_traces(),
-    }
-    any_state.apply_ops(checkpoint);
-
-    Ok(())
-}
-
-pub(crate) fn transition<F: Field>(any_state: &mut State<F>) -> anyhow::Result<()> {
-    let checkpoint = any_state.checkpoint();
-    let result = try_perform_instruction(any_state);
-
-    match result {
-        Ok(op) => {
-            any_state.apply_ops(checkpoint);
-
-            if might_overflow_op(op) {
-                any_state.get_mut_registers().check_overflow = true;
+            &HashMap::default(),
+        );
+        if !should_jump || gen_state.registers.is_kernel {
+            // Don't actually do the read, just set the address, etc.
+            let channel = &mut row.mem_channels[NUM_GP_CHANNELS - 1];
+            channel.used = F::ZERO;
+            channel.value[0] = F::ONE;
+        } else {
+            if jumpdest_bit != U256::one() {
+                return Err(ProgramError::InvalidJumpiDestination);
             }
-            Ok(())
+            gen_state.traces.push_memory(jumpdest_bit_log);
         }
-        Err(e) => {
-            if any_state.get_registers().is_kernel {
-                let offset_name = KERNEL.offset_name(any_state.get_registers().program_counter);
-                bail!(
-                    "{:?} in kernel at pc={}, stack={:?}, memory={:?}",
-                    e,
-                    offset_name,
-                    any_state.get_stack(),
-                    any_state.mem_get_kernel_content(),
-                );
-            }
-            any_state.rollback(checkpoint);
-            handle_error(any_state, e)
+
+        let diff = row.stack_len - F::TWO;
+        if let Some(inv) = diff.try_inverse() {
+            row.general.stack_mut().stack_inv = inv;
+            row.general.stack_mut().stack_inv_aux = F::ONE;
+        } else {
+            row.general.stack_mut().stack_inv = F::ZERO;
+            row.general.stack_mut().stack_inv_aux = F::ZERO;
         }
+
+        gen_state.traces.push_memory(log_cond);
+        gen_state.traces.push_cpu(row);
+        Ok(())
     }
+
+    /// Skips the following instructions for some specific labels
+    fn skip_if_necessary(&mut self, op: Operation) -> Result<Operation, ProgramError>;
+
+    fn get_preinitialized_segments(&self) -> HashMap<Segment, MemorySegmentState>;
+
+    fn perform_op(
+        &mut self,
+        op: Operation,
+        opcode: u8,
+        row: CpuColumnsView<F>,
+    ) -> Result<(), ProgramError> {
+        /// It may
+        let op = self.skip_if_necessary(op)?;
+        let is_interpreter = self.is_generation_state();
+        let preinitialized_segments = self.get_preinitialized_segments();
+
+        #[cfg(debug_assertions)]
+        if !self.get_registers().is_kernel {
+            log::debug!(
+                "User instruction {:?}, stack = {:?}, ctx = {}",
+                op,
+                {
+                    let mut stack = self.get_stack();
+                    stack.reverse();
+                    stack
+                },
+                self.get_registers().context
+            );
+        }
+
+        let generation_state = self.get_mut_generation_state();
+
+        match op {
+            Operation::Push(n) => generate_push(n, generation_state, row)?,
+            Operation::Dup(n) => generate_dup(n, generation_state, row)?,
+            Operation::Swap(n) => generate_swap(n, generation_state, row)?,
+            Operation::Iszero => generate_iszero(generation_state, row)?,
+            Operation::Not => generate_not(generation_state, row)?,
+            Operation::BinaryArithmetic(arithmetic::BinaryOperator::Shl) => {
+                generate_shl(generation_state, row)?
+            }
+            Operation::BinaryArithmetic(arithmetic::BinaryOperator::Shr) => {
+                generate_shr(generation_state, row)?
+            }
+            Operation::Syscall(opcode, stack_values_read, stack_len_increased) => generate_syscall(
+                opcode,
+                stack_values_read,
+                stack_len_increased,
+                generation_state,
+                row,
+            )?,
+            Operation::Eq => generate_eq(generation_state, row)?,
+            Operation::BinaryLogic(binary_logic_op) => {
+                generate_binary_logic_op(binary_logic_op, generation_state, row)?
+            }
+            Operation::BinaryArithmetic(op) => {
+                generate_binary_arithmetic_op(op, generation_state, row)?
+            }
+            Operation::TernaryArithmetic(op) => {
+                generate_ternary_arithmetic_op(op, generation_state, row)?
+            }
+            Operation::KeccakGeneral => generate_keccak_general(
+                generation_state,
+                row,
+                is_interpreter,
+                &preinitialized_segments,
+            )?,
+            Operation::ProverInput => generate_prover_input(generation_state, row)?,
+            Operation::Pop => generate_pop(generation_state, row)?,
+            Operation::Jump => self.generate_jump(row)?,
+            Operation::Jumpi => self.generate_jumpi(row)?,
+            Operation::Pc => generate_pc(generation_state, row)?,
+            Operation::Jumpdest => generate_jumpdest(generation_state, row)?,
+            Operation::GetContext => generate_get_context(generation_state, row)?,
+            Operation::SetContext => generate_set_context(generation_state, row)?,
+            Operation::Mload32Bytes => generate_mload_32bytes(
+                generation_state,
+                row,
+                is_interpreter,
+                &preinitialized_segments,
+            )?,
+            Operation::Mstore32Bytes(n) => generate_mstore_32bytes(n, generation_state, row)?,
+            Operation::ExitKernel => generate_exit_kernel(generation_state, row)?,
+            Operation::MloadGeneral => generate_mload_general(
+                generation_state,
+                row,
+                is_interpreter,
+                &preinitialized_segments,
+            )?,
+            Operation::MstoreGeneral => generate_mstore_general(generation_state, row)?,
+        };
+
+        if !self.is_generation_state() {
+            self.clear_traces();
+        }
+        Ok(())
+    }
+
+    fn fill_stack_fields(&mut self, row: &mut CpuColumnsView<F>) -> Result<(), ProgramError>;
+    // {
+    //     if state.registers.is_stack_top_read && is_generation {
+    //         let channel = &mut row.mem_channels[0];
+    //         channel.used = F::ONE;
+    //         channel.is_read = F::ONE;
+    //         channel.addr_context =
+    // F::from_canonical_usize(state.registers.context);         channel.
+    // addr_segment = F::from_canonical_usize(Segment::Stack.unscale());
+    //         channel.addr_virtual =
+    // F::from_canonical_usize(state.registers.stack_len - 1);
+
+    //         let address = MemoryAddress::new(
+    //             state.registers.context,
+    //             Segment::Stack,
+    //             state.registers.stack_len - 1,
+    //         );
+
+    //         let mem_op = MemoryOp::new(
+    //             GeneralPurpose(0),
+    //             state.traces.clock(),
+    //             address,
+    //             MemoryOpKind::Read,
+    //             state.registers.stack_top,
+    //         );
+    //         state.traces.push_memory(mem_op);
+    //     }
+    //     state.registers.is_stack_top_read = false;
+
+    //     if state.registers.check_overflow && is_generation {
+    //         if state.registers.is_kernel {
+    //             row.general.stack_mut().stack_len_bounds_aux = F::ZERO;
+    //         } else {
+    //             let clock = state.traces.clock();
+    //             let last_row = &mut state.traces.cpu[clock - 1];
+    //             let disallowed_len = F::from_canonical_usize(MAX_USER_STACK_SIZE
+    // + 1);             let diff = row.stack_len - disallowed_len; if let Some(inv)
+    //   = diff.try_inverse() { last_row.general.stack_mut().stack_len_bounds_aux =
+    //   inv; } else { // This is a stack overflow that should have been caught
+    // earlier.                 return Err(ProgramError::InterpreterError);
+    //             }
+    //         }
+    //     }
+    //     state.registers.check_overflow = false;
+
+    //     Ok(())
+    // }
 }

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -474,7 +474,6 @@ pub(crate) trait Transition<F: Field>: State<F> {
         opcode: u8,
         row: CpuColumnsView<F>,
     ) -> Result<(), ProgramError> {
-        /// It may
         let op = self.skip_if_necessary(op)?;
         let preinitialized_segments = self.get_preinitialized_segments();
 

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -478,7 +478,7 @@ pub(crate) trait Transition<F: Field>: State<F> {
     ) -> Result<(), ProgramError> {
         /// It may
         let op = self.skip_if_necessary(op)?;
-        let is_interpreter = self.is_generation_state();
+        let is_interpreter = !self.is_generation_state();
         let preinitialized_segments = self.get_preinitialized_segments();
 
         #[cfg(debug_assertions)]

--- a/evm_arithmetization/src/witness/transition.rs
+++ b/evm_arithmetization/src/witness/transition.rs
@@ -359,7 +359,6 @@ pub(crate) trait Transition<F: Field>: State<F> {
                 ),
                 gen_state,
                 &mut row,
-                false,
                 &HashMap::default(),
             );
 
@@ -436,7 +435,6 @@ pub(crate) trait Transition<F: Field>: State<F> {
             ),
             gen_state,
             &mut row,
-            false,
             &HashMap::default(),
         );
         if !should_jump || gen_state.registers.is_kernel {
@@ -478,7 +476,6 @@ pub(crate) trait Transition<F: Field>: State<F> {
     ) -> Result<(), ProgramError> {
         /// It may
         let op = self.skip_if_necessary(op)?;
-        let is_interpreter = !self.is_generation_state();
         let preinitialized_segments = self.get_preinitialized_segments();
 
         #[cfg(debug_assertions)]
@@ -526,12 +523,9 @@ pub(crate) trait Transition<F: Field>: State<F> {
             Operation::TernaryArithmetic(op) => {
                 generate_ternary_arithmetic_op(op, generation_state, row)?
             }
-            Operation::KeccakGeneral => generate_keccak_general(
-                generation_state,
-                row,
-                is_interpreter,
-                &preinitialized_segments,
-            )?,
+            Operation::KeccakGeneral => {
+                generate_keccak_general(generation_state, row, &preinitialized_segments)?
+            }
             Operation::ProverInput => generate_prover_input(generation_state, row)?,
             Operation::Pop => generate_pop(generation_state, row)?,
             Operation::Jump => self.generate_jump(row)?,
@@ -540,26 +534,18 @@ pub(crate) trait Transition<F: Field>: State<F> {
             Operation::Jumpdest => generate_jumpdest(generation_state, row)?,
             Operation::GetContext => generate_get_context(generation_state, row)?,
             Operation::SetContext => generate_set_context(generation_state, row)?,
-            Operation::Mload32Bytes => generate_mload_32bytes(
-                generation_state,
-                row,
-                is_interpreter,
-                &preinitialized_segments,
-            )?,
+            Operation::Mload32Bytes => {
+                generate_mload_32bytes(generation_state, row, &preinitialized_segments)?
+            }
             Operation::Mstore32Bytes(n) => generate_mstore_32bytes(n, generation_state, row)?,
             Operation::ExitKernel => generate_exit_kernel(generation_state, row)?,
-            Operation::MloadGeneral => generate_mload_general(
-                generation_state,
-                row,
-                is_interpreter,
-                &preinitialized_segments,
-            )?,
+            Operation::MloadGeneral => {
+                generate_mload_general(generation_state, row, &preinitialized_segments)?
+            }
             Operation::MstoreGeneral => generate_mstore_general(generation_state, row)?,
         };
 
-        if !self.is_generation_state() {
-            self.clear_traces();
-        }
+        self.clear_traces();
         Ok(())
     }
 

--- a/evm_arithmetization/src/witness/util.rs
+++ b/evm_arithmetization/src/witness/util.rs
@@ -44,14 +44,11 @@ pub(crate) fn stack_peek<F: Field>(
         return Ok(state.registers.stack_top);
     }
 
-    Ok(state.memory.get(
-        MemoryAddress::new(
-            state.registers.context,
-            Segment::Stack,
-            state.registers.stack_len - 1 - i,
-        ),
-        &HashMap::default(),
-    ))
+    Ok(state.memory.get(MemoryAddress::new(
+        state.registers.context,
+        Segment::Stack,
+        state.registers.stack_len - 1 - i,
+    )))
 }
 
 /// Peek at kernel at specified segment and address
@@ -60,13 +57,9 @@ pub(crate) fn current_context_peek<F: Field>(
     segment: Segment,
     virt: usize,
     is_interpreter: bool,
-    preinitialized_segments: &HashMap<Segment, MemorySegmentState, RandomState>,
 ) -> U256 {
     let context = state.registers.context;
-    state.memory.get(
-        MemoryAddress::new(context, segment, virt),
-        preinitialized_segments,
-    )
+    state.memory.get(MemoryAddress::new(context, segment, virt))
 }
 
 pub(crate) fn fill_channel_with_value<F: Field>(row: &mut CpuColumnsView<F>, n: usize, val: U256) {
@@ -119,9 +112,8 @@ pub(crate) fn mem_read_with_log<F: Field>(
     channel: MemoryChannel,
     address: MemoryAddress,
     state: &GenerationState<F>,
-    preinitialized_segments: &HashMap<Segment, MemorySegmentState, RandomState>,
 ) -> (U256, MemoryOp) {
-    let val = state.memory.get(address, preinitialized_segments);
+    let val = state.memory.get(address);
     let op = MemoryOp::new(
         channel,
         state.traces.clock(),
@@ -152,9 +144,8 @@ pub(crate) fn mem_read_code_with_log_and_fill<F: Field>(
     state: &GenerationState<F>,
     row: &mut CpuColumnsView<F>,
     is_interpreter: bool,
-    preinitialized_segments: &HashMap<Segment, MemorySegmentState, RandomState>,
 ) -> (u8, MemoryOp) {
-    let (val, op) = mem_read_with_log(MemoryChannel::Code, address, state, preinitialized_segments);
+    let (val, op) = mem_read_with_log(MemoryChannel::Code, address, state);
 
     let val_u8 = to_byte_checked(val);
     row.opcode_bits = to_bits_le(val_u8);
@@ -167,14 +158,8 @@ pub(crate) fn mem_read_gp_with_log_and_fill<F: Field>(
     address: MemoryAddress,
     state: &GenerationState<F>,
     row: &mut CpuColumnsView<F>,
-    preinitialized_segments: &HashMap<Segment, MemorySegmentState, RandomState>,
 ) -> (U256, MemoryOp) {
-    let (val, op) = mem_read_with_log(
-        MemoryChannel::GeneralPurpose(n),
-        address,
-        state,
-        preinitialized_segments,
-    );
+    let (val, op) = mem_read_with_log(MemoryChannel::GeneralPurpose(n), address, state);
     let val_limbs: [u64; 4] = val.0;
 
     let channel = &mut row.mem_channels[n];
@@ -263,7 +248,7 @@ pub(crate) fn stack_pop_with_log_and_fill<const N: usize, F: Field>(
                 state.registers.stack_len - 1 - i,
             );
 
-            mem_read_gp_with_log_and_fill(i, address, state, row, &HashMap::default())
+            mem_read_gp_with_log_and_fill(i, address, state, row)
         }
     });
 


### PR DESCRIPTION
# Description

Changes `enum State` to `trait State`,  which is implemented by `Interpreter` and `GenerationState`. The `State` trait require to implement the same methods of the previous enum, and implements the ones having the old enum as input (for example `run_cpu`) . It also required to create a new trait `Transition: State` which implements some the the functions in `trasition.rs` and require to implement others related to the state transition.